### PR TITLE
temporary directory cleanup on program termination

### DIFF
--- a/corsika_wrapper/_api.py
+++ b/corsika_wrapper/_api.py
@@ -48,7 +48,7 @@ def corsika(
     output_path = os.path.abspath(output_path)
 
     # THREAD SAFE
-    with tempfile.TemporaryDirectory(prefix='corsika_') as tmp_dir:
+    with tools.SignalResistantTemporaryDirectory(prefix='corsika_') as tmp_dir:
         tmp_corsika_run_dir = os.path.join(tmp_dir, 'run')
         corsika_run_dir = os.path.dirname(corsika_path)
         shutil.copytree(corsika_run_dir, tmp_corsika_run_dir, symlinks=False)


### PR DESCRIPTION
Hi! Thanks for the great project, I have used it and took some inspiration from it.

One thing I noticed is sometimes I have to kill my processes running `corsika_wrapper`, and in that case temporary directories (`/tmp/corsika_xxxxxx`) are not cleaned up. There are usually several of those and they can accumulate over time, so this can lead to some wasted disk space. I have implemented a simple `TemporaryDirectory` subclass that handles this case by catching termination signals and executing cleanup method. Sadly, this behavior is hard to test, but in my experience it works nicely.

Not sure if the project is actively maintained, but I have implemented this feature in my own fork and decided that it's worth sharing!